### PR TITLE
Fix Spanish translation

### DIFF
--- a/translations/es.json
+++ b/translations/es.json
@@ -1,4 +1,3 @@
-// Thanks to margaritamc
 {
   "TITLE": "Fase Lunar",
   "UPDATE": "Actualizar",


### PR DESCRIPTION
## Description
Removed the commented line in the Spanish JSON file. Adding a comments to JSON renders it invalid.

## Related Issue
[Spanish translation breaks MagicMirror (#15)](https://github.com/NolanKingdon/MMM-MoonPhase/issues/15)

## Motivation and Context
Spanish language was unusable.

## How Has This Been Tested?
Checked that the expected behavior works: MMM-MoonPhase is displayed in Spanish.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/14996002/98304203-d18faa00-1fbf-11eb-84c3-283c98e31d02.png)

Before the fix MagicMirror just displayed a black screen.