### PR TITLE
Fix Issue Preventing Phase update 

### DIFF
--- a/MMM-MoonPhase.js
+++ b/MMM-MoonPhase.js
@@ -28,8 +28,8 @@ Module.register("MMM-MoonPhase", {
 		this.sendSocketNotification('CALCULATE_MOONDATA', this.config);
 
 		// Schedule update timer.
-		setInterval(function() {
-			this.sendSocketNotification('CALCULATE_MOONDATA');
+		setInterval(() => {
+			this.sendSocketNotification('CALCULATE_MOONDATA', this.config);
 			// self.updateDom();
 		}, this.config.updateInterval);
 	},


### PR DESCRIPTION
### Problem

See #30

The `setInterval` call was capturing the scope of `this`. This caused the `sendSocketNotification` to fail as it did not exist in the scope's `this`. The `sendSocketNotification` also was not sending the config object that is required to find the radius of the curve.

### Solution
Change to ES6 function to enable scope of `this` to remain with the parent context that has `sendSocketNotification`. Add config object to match initial function call. 