### PR TITLE
Fix Error with reassigning to Consts in Rise/Set times

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -148,6 +148,10 @@ module.exports = NodeHelper.create({
      * Moon rise/set Functions *
      ***************************/
     _formatTime: function(hourScheme, time) {
+        // If the moon does not rise or set on a given day, it will be one of these
+        if(time.includes('-') || time.includes('*')) {
+            return time;
+        }
         if(time.length !== 4) {
             console.error("Invalid time provided");
             return;
@@ -186,9 +190,9 @@ module.exports = NodeHelper.create({
         let a, b;
 
         const today = new Date();
-        const month = today.getMonth() + 1;
+        let month = today.getMonth() + 1;
         const day = today.getDate();
-        const year = today.getFullYear();
+        let year = today.getFullYear();
         const hour = 0.0;
 
         if (month <= 2) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-moonphase",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "MagicMirror² Module that displays the current moon phase",
   "main": "MMM-MoonPhase.js",
   "author": "Nolan Kingdon",


### PR DESCRIPTION
 - Fix const assignment error when rise/set is in Jan/Feb
 - Tweak the time formatting to account for the non-time results the calculation can spit out when there are no moon rises/sets for a given window

Fix for #41 